### PR TITLE
Whitelabel Error Page при липса на съвпадение

### DIFF
--- a/exam-prep-battle-ships/src/main/java/softuni/examprepbattleships/validations/passwardMatcher/PasswordMatcher.java
+++ b/exam-prep-battle-ships/src/main/java/softuni/examprepbattleships/validations/passwardMatcher/PasswordMatcher.java
@@ -20,7 +20,7 @@ public class PasswordMatcher implements ConstraintValidator<PasswordMatch, UserR
         }
 
         context.buildConstraintViolationWithTemplate(context.getDefaultConstraintMessageTemplate())
-                .addPropertyNode(userRegisterModel.getConfirmPassword())
+                .addPropertyNode("confirmPassword")
                 .addConstraintViolation()
                 .disableDefaultConstraintViolation();
 


### PR DESCRIPTION
На упражнението се появи тази грешка при опит за регистрация, когато полетата password и confirmPassword не съвпадат.

JSR-303 validated property 'асдфг' does not have a corresponding accessor for Spring data binding - check your DataBinder's configuration (bean property versus direct field access)

После някак изчезна, но днес като правих друг изпит и естествено преписах анотацията, защото много ми харесва това решение, се появи пак тази грешка. Дебъгвах и стигнах до context-a. Гледах решения и се чудих какво е. Щом променя addPropertyNode - грешката изчезва.

Интересно ми е дали наистина е това причината.